### PR TITLE
feat: add option exportSportTypes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# One of the following depending on your account:
+# - For America: https://teamapi.coros.com
+# - For Europe: https://teameuapi.coros.com
+# - For China: https://teamcnapi.coros.com
 COROS_API_URL=https://teamapi.coros.com
 COROS_EMAIL=john.doe@example.com
 COROS_PASSWORD=mysecurepassword

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,7 @@ jobs:
         run: npm ci
       - name: Code quality
         run:  npx @biomejs/biome ci src
+      - name: Tests
+        run:  npm run test
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ npx nest start -- export-activities -o ~/Downloads
   -h, --help               display help for command
 ```
 
+## API Documentation
+
+The API used by this project are documented using [Bruno](https://www.usebruno.com/) in the [api folder](./api).
+
 ## Licence
 
 [MIT License](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -12,21 +12,31 @@ anytime.
 - Create a `.env` file (see [.env.example](.env.example)) with your email, password and the Coros API URL
 - Run `npx nest start -- export-activities -out OUT_DIR`.
 
-Example:
+**Options:**
+
+```
+  -o, --out [outDir]              Output directory
+  --exportType <fileType>         Export data type (choices: "fit", "tcx", "gpx", "kml", "csv", default: "fit")
+  --exportSportTypes <sportType>  Export sport types, comma separated (choices: "all", "run", "indoorRun", "trailRun", "trackRun", "hike", "mtnClimb", "bike", "indoorBike", "roadEbike", "gravelRoadBike", "mountainRiding", "mountainEbike", "helmetBike", "poolSwim", "openWater", "triathlon", "strength", "gymCardio", "gpsCardio", "ski", "snowboard", "xcSki", "skiTouring", "skiTouringOld", "multiSport", "speedsurfing", "windsurfing", "row", "indoorRow", "whitewater", "flatwater", "multiPitch", "climb", "indoorClimb", "bouldering", "walk", "jumpRope", "climbStairs", "customSport", default: "all")
+  --fromDate <from>               Export activities created after this date (inclusive). Format must be YYYY-MM-DD
+  --toDate <to>                   Export activities created before this date (inclusive). Format must be YYYY-MM-DD
+  -h, --help                      display help for command
+```
+
+Examples:
 
 ```shell
 # Download all activities in fit format in Downloads folder
 npx nest start -- export-activities -o ~/Downloads
-```
 
-**Options:**
+# Download all activities between 2025-01-01 and 2025-02-01 in fit format in Downloads folder
+npx nest start -- export-activities --fromDate 2025-01-01 --toDate 2025-02-01 -o ~/Downloads
 
-```
-  -o, --out [outDir]       Output directory
-  --exportType <fileType>  Export data type (choices: "fit", "tcx", "gpx", "kml", "csv", default: "fit")
-  --fromDate <from>        Export activities created after this date (inclusive). Format must be YYYY-MM-DD
-  --toDate <to>            Export activities created before this date (inclusive). Format must be YYYY-MM-DD
-  -h, --help               display help for command
+# Download all activities in gpx format in Downloads folder
+npx nest start -- export-activities --exportType gpx -o ~/Downloads
+
+# Download all walk and run in gpx format in Downloads folder
+npx nest start -- export-activities --exportType gpx --exportSportTypes walk,run -o ~/Downloads
 ```
 
 ## API Documentation

--- a/api/Download Activity Detail.bru
+++ b/api/Download Activity Detail.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Download Activity Detail
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{API_URL}}/activity/detail/download?labelId&sportType&fileType
+  body: none
+  auth: none
+}
+
+params:query {
+  labelId: 
+  sportType: 
+  fileType: 
+}
+
+script:pre-request {
+  const loginResponse = await bru.runRequest("Login");
+  req.setHeader("accessToken",  loginResponse.data.data.accessToken);
+}
+
+docs {
+  # Download Activity Detail
+  
+  Query Parameters:
+  
+  - `labelId`: label ID of the activity, you can get it from the `Query Activities` request
+  - `sportType`: sport type of the actity, you can get it from the `Query Activities` request
+  - `fileType`: one of the following depending on the type of file you want
+    - `4`: fit
+    - `3`: tcx
+    - `2`: kml
+    - `1`: gpx
+    - `0`: csv
+}

--- a/api/Login.bru
+++ b/api/Login.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Login
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{API_URL}}/account/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "accountType": 2,
+    "account": "{{COROS_EMAIL}}",
+    "pwd": "{{COROS_PASSWORD_MD5}}"
+  }
+}
+
+docs {
+  # Login
+  
+  Used as a pre-request for other request in order to dynamically set the accessToken.
+}

--- a/api/Query Activities.bru
+++ b/api/Query Activities.bru
@@ -1,0 +1,74 @@
+meta {
+  name: Query Activities
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{API_URL}}/activity/query?size=1&pageNumber=1
+  body: none
+  auth: none
+}
+
+params:query {
+  size: 1
+  pageNumber: 1
+  ~from: 
+  ~to: 
+  ~modeList: 
+}
+
+script:pre-request {
+  const loginResponse = await bru.runRequest("Login");
+  req.setHeader("accessToken",  loginResponse.data.data.accessToken);
+}
+
+docs {
+  # Query Activities
+  
+  Query Parameters:
+  
+  - `size`: number of activities to fetch (must be between 1 and 200)
+  - `pageNumber`: page number (must be at least one)
+  - `from`: start date (format YYYYMMDD), optional
+  - `end`: end date (format YYYYMMDD), optional
+  - `modeList`: list of sport to includes (comma separated values), optional
+  	- `100`: Run
+  	- `101`: Indoor Run
+  	- `102`: Trail Run
+  	- `103`: Track Run
+  	- `104`: Hike  
+  	- `105`: Mtn Climb  
+  	- `106`: Climb  
+  	- `200`: Road Bike  
+  	- `201`: Indoor Bike  
+  	- `202`: E-Bike  
+  	- `203`: Gravel Bike  
+  	- `204`: Mountain Bike  
+  	- `205`: E-MTB  
+  	- `299`: Helmet Riding  
+  	- `300`: Pool Swim  
+  	- `301`: Open Water  
+  	- `400`: Gym Cardio  
+  	- `401`: GPS Cardio  
+  	- `402`: Strength  
+  	- `500`: Ski  
+  	- `501`: Snowboard  
+  	- `502`: XC Ski  
+  	- `503`: Ski Touring  
+  	- `700`: Rowing  
+  	- `701`: Indoor Rower  
+  	- `702`: Whitewater  
+  	- `704`: Flatwater  
+  	- `705`: Windsurfing  
+  	- `706`: Speedsurfing  
+  	- `800`: Indoor Climb  
+  	- `801`: Bouldering  
+  	- `900`: Walk  
+  	- `901`: Jump Rope  
+  	- `902`: Floor Climb  
+  	- `10000`: Triathlon  
+  	- `10001`: Multisport  
+  	- `10002`: Ski Touring  
+  	- `10003`: Outdoor Climb
+}

--- a/api/bruno.json
+++ b/api/bruno.json
@@ -1,0 +1,12 @@
+{
+  "version": "1",
+  "name": "Coros",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"],
+  "size": 0,
+  "filesCount": 0,
+  "presets": {
+    "requestType": "http",
+    "requestUrl": "{{API_URL}}"
+  }
+}

--- a/api/collection.bru
+++ b/api/collection.bru
@@ -1,0 +1,21 @@
+docs {
+  # Coros API
+  
+  Collection of APIs used by [xballoy/coros-api](https://github.com/xballoy/coros-api).
+  
+  ## Prerequisites
+  ### Collection Environment
+  
+  To use the collection, select the environment corresponding to your Coros account:
+  
+  - America
+  - Europe
+  - China
+  
+  ### Global Environment
+  
+  Create a global environment with the following keys:
+  
+  - `COROS_EMAIL`: email used to login to you Coros account, should be the same than `COROS_EMAIL` in the `.env` file
+  - `COROS_PASSWORD_MD5`: md5 value of the password used to login to your Coros account
+}

--- a/api/environments/America.bru
+++ b/api/environments/America.bru
@@ -1,0 +1,3 @@
+vars {
+  API_URL: https://teamapi.coros.com
+}

--- a/api/environments/China.bru
+++ b/api/environments/China.bru
@@ -1,0 +1,3 @@
+vars {
+  API_URL: https://teamcnapi.coros.com
+}

--- a/api/environments/Europe.bru
+++ b/api/environments/Europe.bru
@@ -1,0 +1,3 @@
+vars {
+  API_URL: https://teameuapi.coros.com
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@tsconfig/node20": "20.1.4",
         "@types/node": "22.13.4",
         "@vitest/coverage-v8": "3.0.6",
+        "fast-check": "3.23.2",
         "lefthook": "1.10.10",
         "source-map-support": "0.5.21",
         "typescript": "5.7.3",
@@ -4500,6 +4501,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6500,6 +6524,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "coros-api",
       "version": "2.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@nestjs/axios": "4.0.0",
@@ -16,6 +17,7 @@
         "dayjs": "1.11.13",
         "dotenv": "16.4.7",
         "nest-commander": "3.16.0",
+        "patch-package": "8.0.0",
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.1",
         "zod": "3.24.2"
@@ -3288,6 +3290,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -3489,6 +3497,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
@@ -3511,7 +3528,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -3615,7 +3631,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3737,6 +3752,24 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3748,6 +3781,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3853,6 +3902,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-cursor": {
@@ -3982,7 +4046,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/consola": {
@@ -4044,7 +4107,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4149,6 +4211,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -4692,7 +4771,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4715,6 +4793,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/follow-redirects": {
@@ -4905,6 +4992,12 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5081,7 +5174,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -5101,6 +5193,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -5228,6 +5332,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5325,6 +5440,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5370,7 +5500,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5411,11 +5540,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5566,6 +5712,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+      "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5590,13 +5755,21 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/keyv": {
@@ -5617,6 +5790,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/lefthook": {
@@ -5941,7 +6123,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5955,7 +6136,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6037,7 +6217,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6195,6 +6374,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -6205,6 +6402,22 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6333,11 +6546,73 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6702,6 +6977,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.34.7",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.7.tgz",
@@ -6890,7 +7221,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6938,11 +7268,27 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6955,7 +7301,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7553,7 +7898,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7699,7 +8043,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -8097,7 +8440,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8201,6 +8543,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tsconfig/node20": "20.1.4",
     "@types/node": "22.13.4",
     "@vitest/coverage-v8": "3.0.6",
+    "fast-check": "3.23.2",
     "lefthook": "1.10.10",
     "source-map-support": "0.5.21",
     "typescript": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "nest start",
     "start:prod": "node dist/main",
     "lint:check": "biome lint src",
-    "lint:fix": "biome lint --apply src"
+    "lint:fix": "biome lint --apply src",
+    "test": "vitest --run"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "description": "Coros API",
   "scripts": {
+    "postinstall": "patch-package",
     "build": "nest build",
     "format:check": "biome format src",
     "format:fix": "biome format --write src",
@@ -47,6 +48,7 @@
     "dayjs": "1.11.13",
     "dotenv": "16.4.7",
     "nest-commander": "3.16.0",
+    "patch-package": "8.0.0",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.1",
     "zod": "3.24.2"

--- a/patches/nest-commander+3.16.0.patch
+++ b/patches/nest-commander+3.16.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/nest-commander/src/command-runner.interface.d.ts b/node_modules/nest-commander/src/command-runner.interface.d.ts
+index 65265f0..2836f20 100644
+--- a/node_modules/nest-commander/src/command-runner.interface.d.ts
++++ b/node_modules/nest-commander/src/command-runner.interface.d.ts
+@@ -26,7 +26,8 @@ export type RootCommandMetadata = Omit<CommandMetadata, 'name'> & {
+ export interface OptionMetadata {
+     flags: string;
+     description?: string;
+-    defaultValue?: string | boolean | number;
++    // Match commander.js type for defaultValue (https://github.com/tj/commander.js/blob/v11.1.0/typings/index.d.ts#L53)
++    defaultValue?: any;
+     required?: boolean;
+     name?: string;
+     choices?: string[] | true;

--- a/src/command-runner/export-activities.command-runner.ts
+++ b/src/command-runner/export-activities.command-runner.ts
@@ -52,13 +52,17 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
     });
 
     for (const { labelId, sportType, fileName } of activitiesToDownload) {
-      const { fileUrl } = await this.corosService.downloadActivityDetail({
-        labelId,
-        sportType,
-        fileType: fileType.value,
-      });
-      await this.downloadFileCommand.handle(fileUrl, outDir, fileName);
-      this.logger.debug(`Downloading ${fileName} success`);
+      try {
+        const { fileUrl } = await this.corosService.downloadActivityDetail({
+          labelId,
+          sportType,
+          fileType: fileType.value,
+        });
+        await this.downloadFileCommand.handle(fileUrl, outDir, fileName);
+        this.logger.debug(`Downloading ${fileName} success`);
+      } catch (error) {
+        this.logger.error(`Downloading ${fileName} failed`);
+      }
     }
   }
 

--- a/src/command-runner/export-activities.command-runner.ts
+++ b/src/command-runner/export-activities.command-runner.ts
@@ -76,7 +76,7 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
   })
   parseOutDir(out: string) {
     if (!existsSync(out)) {
-      throw new InvalidParameterError('out', `${out} directory does not exists`);
+      throw new InvalidParameterError('out', out, 'Directory does not exists');
     }
 
     return out;
@@ -92,7 +92,7 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
   })
   parseFileType(fileType: string): FileTypeFlag {
     if (!isValidFileTypeKey(fileType)) {
-      throw new InvalidParameterError('exportType', `Must be one of: ${FileTypeKeys.join(', ')}.`);
+      throw new InvalidParameterError('exportType', fileType, `Must be one of: ${FileTypeKeys.join(', ')}.`);
     }
 
     return getFileTypeFromKey(fileType);
@@ -109,7 +109,11 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
   parseSportType(sportTypes: string): SportTypesFlag {
     const invalidSportTypes = sportTypes.split(',').filter((sportType) => !isValidSportTypeKey(sportType));
     if (invalidSportTypes.length) {
-      throw new InvalidParameterError('sportType', `Must be comma separated values of: ${SportTypeKeys.join(', ')}.`);
+      throw new InvalidParameterError(
+        'sportType',
+        invalidSportTypes.join(', '),
+        `Must be comma separated values of: ${SportTypeKeys.join(', ')}.`,
+      );
     }
 
     return sportTypes.split(',').filter(isValidSportTypeKey).map(getSportTypeValueFromKey);
@@ -124,7 +128,7 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
   parseFrom(from: string): Date {
     const maybeDate = dayjs(from, 'YYYY-MM-DD', true);
     if (!maybeDate.isValid()) {
-      throw new InvalidParameterError('fromDate', 'Format must be YYYY-MM-DD');
+      throw new InvalidParameterError('fromDate', from, 'Format must be YYYY-MM-DD');
     }
 
     return maybeDate.toDate();
@@ -139,7 +143,7 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
   parseTo(to: string): Date {
     const maybeDate = dayjs(to, 'YYYY-MM-DD', true);
     if (!maybeDate.isValid()) {
-      throw new InvalidParameterError('toDate', 'Format must be YYYY-MM-DD');
+      throw new InvalidParameterError('toDate', to, 'Format must be YYYY-MM-DD');
     }
 
     return maybeDate.toDate();

--- a/src/command-runner/export-activities.command-runner.ts
+++ b/src/command-runner/export-activities.command-runner.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import { Command, CommandRunner, Option } from 'nest-commander';
 import { DownloadFile } from '../core/download-file.service';
 import { CorosAPI } from '../coros/coros-api';
-import { DefaultFileType, FileTypeKeys, getFileTypeFromKey, isValidFileType } from '../coros/file-type';
+import { DefaultFileType, FileTypeKeys, getFileTypeFromKey, isValidFileTypeKey } from '../coros/file-type';
 import { InvalidParameterError } from './invalid-parameter-error';
 
 type Flags = {
@@ -79,7 +79,7 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
     required: false,
   })
   parseFileType(fileType: string): { key: string; value: string } {
-    if (!isValidFileType(fileType)) {
+    if (!isValidFileTypeKey(fileType)) {
       throw new InvalidParameterError('exportType', `Must be one of: ${FileTypeKeys.join(', ')}.`);
     }
 

--- a/src/command-runner/invalid-parameter-error.ts
+++ b/src/command-runner/invalid-parameter-error.ts
@@ -1,6 +1,6 @@
 export class InvalidParameterError extends Error {
-  constructor(parameterName: string, reason?: string) {
-    super(`Invalid parameter ${parameterName}${reason ? `: ${reason}` : ''}`);
+  constructor(parameterName: string, value: string, reason: string) {
+    super(`Invalid value ${value} for parameter ${parameterName}. ${reason}`);
     this.name = 'InvalidParameterError';
   }
 }

--- a/src/coros/coros-api.ts
+++ b/src/coros/coros-api.ts
@@ -15,8 +15,20 @@ export class CorosAPI {
     return await this.loginCommand.run({});
   }
 
-  async queryActivities({ from, to, page, size }: { from?: Date; to?: Date; size?: number; page?: number }) {
-    return await this.queryActivitiesCommand.run({ from, to, pageSize: size, pageNumber: page });
+  async queryActivities({
+    from,
+    to,
+    page,
+    size,
+    sportTypes,
+  }: { from?: Date; to?: Date; size?: number; page?: number; sportTypes: string[] }) {
+    return await this.queryActivitiesCommand.run({
+      from,
+      to,
+      pageSize: size,
+      pageNumber: page,
+      modeList: sportTypes.join(','),
+    });
   }
 
   async downloadActivityDetail({

--- a/src/coros/file-type.spec.ts
+++ b/src/coros/file-type.spec.ts
@@ -1,0 +1,65 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { DefaultFileType, FileTypeKeys, getFileTypeFromKey, isValidFileTypeKey } from './file-type';
+
+const ValidFileTypes = ['fit', 'tcx', 'gpx', 'kml', 'csv'];
+const InvalidFileTypeArbitrary = fc.string().filter((fileType) => !ValidFileTypes.includes(fileType));
+
+describe('File Type', () => {
+  it('should return FileTypeKeys', () => {
+    expect(FileTypeKeys).toMatchInlineSnapshot(`
+      [
+        "fit",
+        "tcx",
+        "gpx",
+        "kml",
+        "csv",
+      ]
+    `);
+  });
+
+  it('should return DefaultFileType', () => {
+    expect(DefaultFileType).toMatchInlineSnapshot(`
+      {
+        "key": "fit",
+        "value": "4",
+      }
+    `);
+  });
+
+  describe('isValidFileTypeKey', () => {
+    it.each(ValidFileTypes)('%s should be valid a valid file type', (fileType) => {
+      expect(isValidFileTypeKey(fileType)).toBe(true);
+    });
+
+    it('should be an invalid file type', () => {
+      fc.assert(
+        fc.property(InvalidFileTypeArbitrary, (input) => {
+          expect(isValidFileTypeKey(input)).toBe(false);
+        }),
+      );
+    });
+  });
+
+  describe('getFileTypeFromKey', () => {
+    it('should return the file type for fit', () => {
+      expect(getFileTypeFromKey('fit')).toEqual({ key: 'fit', value: '4' });
+    });
+
+    it('should return the file type for tcx', () => {
+      expect(getFileTypeFromKey('tcx')).toEqual({ key: 'tcx', value: '3' });
+    });
+
+    it('should return the file type for gpx', () => {
+      expect(getFileTypeFromKey('gpx')).toEqual({ key: 'gpx', value: '1' });
+    });
+
+    it('should return the file type for kml', () => {
+      expect(getFileTypeFromKey('kml')).toEqual({ key: 'kml', value: '2' });
+    });
+
+    it('should return the file type for csv', () => {
+      expect(getFileTypeFromKey('csv')).toEqual({ key: 'csv', value: '0' });
+    });
+  });
+});

--- a/src/coros/file-type.ts
+++ b/src/coros/file-type.ts
@@ -1,27 +1,22 @@
-enum FileType {
-  fit = 0,
-  tcx = 1,
-  gpx = 2,
-  kml = 3,
-  csv = 4,
-}
-export type FileTypeKey = keyof typeof FileType;
+type FileTypeKey = 'fit' | 'tcx' | 'gpx' | 'kml' | 'csv';
 
-const AllFileTypes: Record<FileType, { key: string; value: string }> = {
-  [FileType.fit]: { key: 'fit', value: '4' },
-  [FileType.tcx]: { key: 'tcx', value: '3' },
-  [FileType.gpx]: { key: 'gpx', value: '1' },
-  [FileType.kml]: { key: 'kml', value: '2' },
-  [FileType.csv]: { key: 'csv', value: '0' },
+const AllFileTypes: {
+  [T in FileTypeKey]: { key: T; value: string };
+} = {
+  fit: { key: 'fit', value: '4' },
+  tcx: { key: 'tcx', value: '3' },
+  gpx: { key: 'gpx', value: '1' },
+  kml: { key: 'kml', value: '2' },
+  csv: { key: 'csv', value: '0' },
 };
 
-export const FileTypeKeys = Object.values(AllFileTypes).map(({ key }) => key);
-export const DefaultFileType = AllFileTypes[FileType.fit];
+export const FileTypeKeys: FileTypeKey[] = Object.values(AllFileTypes).map(({ key }) => key);
+export const DefaultFileType = AllFileTypes.fit;
 
 export const getFileTypeFromKey = (value: FileTypeKey) => {
-  return AllFileTypes[FileType[value]];
+  return AllFileTypes[value];
 };
 
-export const isValidFileType = (value: string): value is FileTypeKey => {
-  return Object.keys(FileType).some((it) => it === value);
+export const isValidFileTypeKey = (value: string): value is FileTypeKey => {
+  return Object.keys(AllFileTypes).some((it) => it === value);
 };

--- a/src/coros/sport-type.ts
+++ b/src/coros/sport-type.ts
@@ -1,0 +1,97 @@
+type SportTypeKey =
+  | 'all'
+  | 'run'
+  | 'indoorRun'
+  | 'trailRun'
+  | 'trackRun'
+  | 'hike'
+  | 'mtnClimb'
+  | 'bike'
+  | 'indoorBike'
+  | 'roadEbike'
+  | 'gravelRoadBike'
+  | 'mountainRiding'
+  | 'mountainEbike'
+  | 'helmetBike'
+  | 'poolSwim'
+  | 'openWater'
+  | 'triathlon'
+  | 'strength'
+  | 'gymCardio'
+  | 'gpsCardio'
+  | 'ski'
+  | 'snowboard'
+  | 'xcSki'
+  | 'skiTouring'
+  | 'skiTouringOld'
+  | 'multiSport'
+  | 'speedsurfing'
+  | 'windsurfing'
+  | 'row'
+  | 'indoorRow'
+  | 'whitewater'
+  | 'flatwater'
+  | 'multiPitch'
+  | 'climb'
+  | 'indoorClimb'
+  | 'bouldering'
+  | 'walk'
+  | 'jumpRope'
+  | 'climbStairs'
+  | 'customSport';
+
+const AllSportTypes: {
+  [T in SportTypeKey]: { key: T; value: string };
+} = {
+  all: { key: 'all', value: '0' },
+  run: { key: 'run', value: '100' },
+  indoorRun: { key: 'indoorRun', value: '101' },
+  trailRun: { key: 'trailRun', value: '102' },
+  trackRun: { key: 'trackRun', value: '103' },
+  hike: { key: 'hike', value: '104' },
+  mtnClimb: { key: 'mtnClimb', value: '105' },
+  bike: { key: 'bike', value: '200' },
+  indoorBike: { key: 'indoorBike', value: '201' },
+  roadEbike: { key: 'roadEbike', value: '202' },
+  gravelRoadBike: { key: 'gravelRoadBike', value: '203' },
+  mountainRiding: { key: 'mountainRiding', value: '204' },
+  mountainEbike: { key: 'mountainEbike', value: '205' },
+  helmetBike: { key: 'helmetBike', value: '299' },
+  poolSwim: { key: 'poolSwim', value: '300' },
+  openWater: { key: 'openWater', value: '301' },
+  triathlon: { key: 'triathlon', value: '10000' },
+  strength: { key: 'strength', value: '402' },
+  gymCardio: { key: 'gymCardio', value: '400' },
+  gpsCardio: { key: 'gpsCardio', value: '401' },
+  ski: { key: 'ski', value: '500' },
+  snowboard: { key: 'snowboard', value: '501' },
+  xcSki: { key: 'xcSki', value: '502' },
+  skiTouring: { key: 'skiTouring', value: '503' },
+  skiTouringOld: { key: 'skiTouringOld', value: '10002' },
+  multiSport: { key: 'multiSport', value: '10001' },
+  speedsurfing: { key: 'speedsurfing', value: '706' },
+  windsurfing: { key: 'windsurfing', value: '705' },
+  row: { key: 'row', value: '700' },
+  indoorRow: { key: 'indoorRow', value: '701' },
+  whitewater: { key: 'whitewater', value: '702' },
+  flatwater: { key: 'flatwater', value: '704' },
+  multiPitch: { key: 'multiPitch', value: '10003' },
+  climb: { key: 'climb', value: '106' },
+  indoorClimb: { key: 'indoorClimb', value: '800' },
+  bouldering: { key: 'bouldering', value: '801' },
+  walk: { key: 'walk', value: '900' },
+  jumpRope: { key: 'jumpRope', value: '901' },
+  climbStairs: { key: 'climbStairs', value: '902' },
+  customSport: { key: 'customSport', value: '98' },
+};
+
+export const SportTypeKeys: SportTypeKey[] = Object.values(AllSportTypes).map(({ key }) => key);
+export const DefaultSportType = AllSportTypes.all;
+
+export const getSportTypeFromKey = (value: SportTypeKey) => {
+  return AllSportTypes[value];
+};
+
+export const isValidSportTypeKey = (value: string): value is SportTypeKey => {
+  return Object.keys(AllSportTypes).some((it) => it === value);
+};

--- a/src/coros/sport-type.ts
+++ b/src/coros/sport-type.ts
@@ -88,8 +88,8 @@ const AllSportTypes: {
 export const SportTypeKeys: SportTypeKey[] = Object.values(AllSportTypes).map(({ key }) => key);
 export const DefaultSportType = AllSportTypes.all;
 
-export const getSportTypeFromKey = (value: SportTypeKey) => {
-  return AllSportTypes[value];
+export const getSportTypeValueFromKey = (value: SportTypeKey) => {
+  return AllSportTypes[value].value;
 };
 
 export const isValidSportTypeKey = (value: string): value is SportTypeKey => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,7 @@
 
     "outDir": "./dist",
     "baseUrl": "./",
+
+    "types": ["vitest/globals"]
   }
 }


### PR DESCRIPTION
## Added

### `exportSportTypes` option

Add option `exportSportTypes` to include only certain sport in the export.

Usage:

```
# Export only run and walk
npx nest start -- export-activities --exportSportTypes run,walk -o ~/Downloads

# Export only run
npx nest start -- export-activities --exportSportTypes run -o ~/Downloads
```

### API collection

Add an API collection using Bruno of the API used by the project.

## Changed

- Remove logic around `exportType` to remove the `enum` and add tests.
- Improve documentation
- Prevent crashing when downloading fails

Fixes #353 