### PR TITLE
refactor: remove TypeScript only syntax to prepare for TypeScript 5.8 option erasableSyntaxOnly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@swc-node/register": "1.10.9",
         "@swc/cli": "0.6.0",
         "@swc/core": "1.10.17",
-        "@tsconfig/node20": "20.1.4",
+        "@tsconfig/node22": "22.0.0",
         "@types/node": "22.13.4",
         "@vitest/coverage-v8": "3.0.6",
         "fast-check": "3.23.2",
@@ -2710,10 +2710,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
-      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.0.tgz",
+      "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@swc-node/register": "1.10.9",
     "@swc/cli": "0.6.0",
     "@swc/core": "1.10.17",
-    "@tsconfig/node20": "20.1.4",
+    "@tsconfig/node22": "22.0.0",
     "@types/node": "22.13.4",
     "@vitest/coverage-v8": "3.0.6",
     "fast-check": "3.23.2",

--- a/src/command-runner/export-activities.command-runner.ts
+++ b/src/command-runner/export-activities.command-runner.ts
@@ -21,12 +21,13 @@ type Flags = {
 @Command({ name: 'export-activities', description: 'Bulk export your Coros activities' })
 export class ExportActivitiesCommandRunner extends CommandRunner {
   private readonly logger = new Logger(ExportActivitiesCommandRunner.name);
+  private readonly downloadFileCommand: DownloadFile;
+  private readonly corosService: CorosAPI;
 
-  constructor(
-    private readonly downloadFileCommand: DownloadFile,
-    private readonly corosService: CorosAPI,
-  ) {
+  constructor(downloadFileCommand: DownloadFile, corosService: CorosAPI) {
     super();
+    this.corosService = corosService;
+    this.downloadFileCommand = downloadFileCommand;
   }
 
   async run(_passedParams: string[], flags: Flags): Promise<void> {

--- a/src/core/download-file.service.ts
+++ b/src/core/download-file.service.ts
@@ -7,8 +7,11 @@ import { Injectable, Logger } from '@nestjs/common';
 @Injectable()
 export class DownloadFile {
   private readonly logger = new Logger(DownloadFile.name);
+  private readonly httpService: HttpService;
 
-  constructor(private readonly httpService: HttpService) {}
+  constructor(httpService: HttpService) {
+    this.httpService = httpService;
+  }
 
   async handle(url: string, directory: string, fileName: string): Promise<void> {
     this.logger.log(`Downloading ${fileName}`);

--- a/src/core/validation-error.ts
+++ b/src/core/validation-error.ts
@@ -1,17 +1,19 @@
 import type { z } from 'zod';
 
 export class ValidationError extends Error {
-  constructor(
-    public readonly issues: z.ZodIssue[],
-    public readonly options?: ErrorOptions,
-  ) {
+  public readonly issues: z.ZodIssue[];
+  public readonly options?: ErrorOptions;
+
+  constructor(issues: z.ZodIssue[], options?: ErrorOptions) {
     super(ValidationError.getMessage(issues), options);
+    this.options = options;
+    this.issues = issues;
     this.name = 'ValidationError';
   }
 
   private static getMessage(issues: z.ZodIssue[]): string {
     return Object.entries(issues.flat())
-      .map(([key, issue]) => `${issue.path.join('.')} => ${issue.message}`)
+      .map(([_, issue]) => `${issue.path.join('.')} => ${issue.message}`)
       .join(', ');
   }
 }

--- a/src/coros/account/login.request.ts
+++ b/src/coros/account/login.request.ts
@@ -29,13 +29,19 @@ type LoginInput = z.infer<typeof LoginInput>;
 @Injectable()
 export class LoginRequest extends BaseRequest<LoginInput, LoginResponse, Omit<LoginData, 'accessToken'>> {
   private readonly logger = new Logger(LoginRequest.name);
+  private readonly httpService: HttpService;
+  private readonly corosConfig: CorosConfigService;
+  private readonly corosAuthenticationService: CorosAuthenticationService;
 
   constructor(
-    private readonly httpService: HttpService,
-    private readonly corosConfig: CorosConfigService,
-    private readonly corosAuthenticationService: CorosAuthenticationService,
+    httpService: HttpService,
+    corosConfig: CorosConfigService,
+    corosAuthenticationService: CorosAuthenticationService,
   ) {
     super();
+    this.corosAuthenticationService = corosAuthenticationService;
+    this.corosConfig = corosConfig;
+    this.httpService = httpService;
   }
 
   protected inputValidator(): z.Schema<LoginInput> {

--- a/src/coros/activity/download-activity-detail.request.ts
+++ b/src/coros/activity/download-activity-detail.request.ts
@@ -28,13 +28,19 @@ export class DownloadActivityDetailRequest extends BaseRequest<
   DownloadActivityDetailResponse
 > {
   private readonly logger = new Logger(DownloadActivityDetailRequest.name);
+  private readonly httpService: HttpService;
+  private readonly corosConfig: CorosConfigService;
+  private readonly corosAuthenticationService: CorosAuthenticationService;
 
   constructor(
-    private readonly httpService: HttpService,
-    private readonly corosConfig: CorosConfigService,
-    private readonly corosAuthenticationService: CorosAuthenticationService,
+    httpService: HttpService,
+    corosConfig: CorosConfigService,
+    corosAuthenticationService: CorosAuthenticationService,
   ) {
     super();
+    this.corosAuthenticationService = corosAuthenticationService;
+    this.corosConfig = corosConfig;
+    this.httpService = httpService;
   }
 
   protected inputValidator(): z.Schema<DownloadActivityDetailInput> {

--- a/src/coros/activity/query-activities.request.ts
+++ b/src/coros/activity/query-activities.request.ts
@@ -48,13 +48,19 @@ export class QueryActivitiesRequest extends BaseRequest<
   QueryActivitiesOutput
 > {
   private readonly logger = new Logger(QueryActivitiesRequest.name);
+  private readonly httpService: HttpService;
+  private readonly corosConfig: CorosConfigService;
+  private readonly corosAuthenticationService: CorosAuthenticationService;
 
   constructor(
-    private readonly httpService: HttpService,
-    private readonly corosConfig: CorosConfigService,
-    private readonly corosAuthenticationService: CorosAuthenticationService,
+    httpService: HttpService,
+    corosConfig: CorosConfigService,
+    corosAuthenticationService: CorosAuthenticationService,
   ) {
     super();
+    this.corosAuthenticationService = corosAuthenticationService;
+    this.corosConfig = corosConfig;
+    this.httpService = httpService;
   }
 
   protected inputValidator(): z.Schema<QueryActivitiesInput> {

--- a/src/coros/coros-api.ts
+++ b/src/coros/coros-api.ts
@@ -5,11 +5,19 @@ import { QueryActivitiesRequest } from './activity/query-activities.request';
 
 @Injectable()
 export class CorosAPI {
+  private readonly loginCommand: LoginRequest;
+  private readonly queryActivitiesCommand: QueryActivitiesRequest;
+  private readonly downloadActivityDetailCommand: DownloadActivityDetailRequest;
+
   constructor(
-    private readonly loginCommand: LoginRequest,
-    private readonly queryActivitiesCommand: QueryActivitiesRequest,
-    private readonly downloadActivityDetailCommand: DownloadActivityDetailRequest,
-  ) {}
+    loginCommand: LoginRequest,
+    queryActivitiesCommand: QueryActivitiesRequest,
+    downloadActivityDetailCommand: DownloadActivityDetailRequest,
+  ) {
+    this.downloadActivityDetailCommand = downloadActivityDetailCommand;
+    this.queryActivitiesCommand = queryActivitiesCommand;
+    this.loginCommand = loginCommand;
+  }
 
   async login() {
     return await this.loginCommand.run({});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Remove unsupported syntax for Node.js `--experimental-strip-types` and to prepare for TypeScript 5.8 option `erasableSyntaxOnly`.

See https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-rc/#the---erasablesyntaxonly-option