### PR TITLE
chore: cleanup packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@vitest/coverage-v8": "3.2.4",
     "fast-check": "4.1.1",
     "lefthook": "1.11.14",
-    "source-map-support": "0.5.21",
     "typescript": "5.8.3",
     "unplugin-swc": "1.5.5",
     "vitest": "3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       lefthook:
         specifier: 1.11.14
         version: 1.11.14
-      source-map-support:
-        specifier: 0.5.21
-        version: 0.5.21
       typescript:
         specifier: 5.8.3
         version: 5.8.3

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>xballoy/renovate-config"],
+  "packageRules": [
+    {
+      "matchDepNames": ["reflect-metadata"],
+      "abandonmentThreshold": null
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
- Remove unnecessary package `source-map-support`
- Update Renovate config to not flag `reflect-metadata` as abandonned