### PR TITLE
fix: handle activities with missing name field

### DIFF
--- a/src/command-runner/export-activities.command-runner.ts
+++ b/src/command-runner/export-activities.command-runner.ts
@@ -46,11 +46,12 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
 
     const activitiesToDownload = activities.map((it) => {
       const activityDate = dayjs(String(it.date), 'YYYYMMDD');
+      const activityName = it.name?.trim() || 'Activity';
 
       return {
         labelId: it.labelId,
         sportType: it.sportType,
-        fileName: `${activityDate.format('YYYY-MM-DD')} ${it.name.trim()} ${it.labelId}.${fileType.key}`,
+        fileName: `${activityDate.format('YYYY-MM-DD')} ${activityName} ${it.labelId}.${fileType.key}`,
       };
     });
 

--- a/src/coros/activity/query-activities.request.ts
+++ b/src/coros/activity/query-activities.request.ts
@@ -20,7 +20,7 @@ export type QueryActivitiesInput = z.infer<typeof QueryActivitiesInput>;
 export const Activity = z.object({
   date: z.number(),
   labelId: z.string(),
-  name: z.string(),
+  name: z.string().nullish(),
   sportType: z.number(),
 });
 export type Activity = z.infer<typeof Activity>;


### PR DESCRIPTION
The Coros API can return activities without a name field (null or undefined), causing zod validation to fail and print raw JSON response to console. Make the name field nullable and use 'Activity' as fallback.

Fixes #779
