### PR TITLE
fix: harden security, ICS compliance, and error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.16.0"
+          cache: pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Code quality

--- a/src/command-runner/export-activities.command-runner.integration.spec.ts
+++ b/src/command-runner/export-activities.command-runner.integration.spec.ts
@@ -49,6 +49,7 @@ describe('export-activities', () => {
 
   afterEach(async () => {
     server.resetHandlers();
+    process.exitCode = undefined;
     await rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -164,6 +165,7 @@ describe('export-activities', () => {
     const files = await readdir(tmpDir);
     expect(files).toHaveLength(1);
     expect(files[0]).toBe('2025-01-20 Good Run ok-activity.fit');
+    expect(process.exitCode).toBe(1);
   });
 
   it('respects --exportType gpx', async () => {

--- a/src/command-runner/export-activities.command-runner.ts
+++ b/src/command-runner/export-activities.command-runner.ts
@@ -47,7 +47,8 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
 
     const activitiesToDownload = activities.map((it) => {
       const activityDate = dayjs(String(it.date), 'YYYYMMDD');
-      const activityName = it.name?.trim() || 'Activity';
+      // The activity name comes from the API: strip path separators so it cannot escape the output directory
+      const activityName = (it.name?.trim() || 'Activity').replace(/[/\\]/g, '-');
 
       return {
         labelId: it.labelId,
@@ -56,6 +57,7 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
       };
     });
 
+    let failedDownloads = 0;
     for (const { labelId, sportType, fileName } of activitiesToDownload) {
       try {
         const { fileUrl } = await this.corosService.downloadActivityDetail({
@@ -65,9 +67,15 @@ export class ExportActivitiesCommandRunner extends CommandRunner {
         });
         await this.downloadFileCommand.handle(fileUrl, outDir, fileName);
         this.logger.debug(`Downloading ${fileName} success`);
-      } catch {
-        this.logger.error(`Downloading ${fileName} failed`);
+      } catch (error) {
+        failedDownloads += 1;
+        this.logger.error(`Downloading ${fileName} failed`, error instanceof Error ? error.stack : error);
       }
+    }
+
+    if (failedDownloads > 0) {
+      this.logger.error(`${failedDownloads} of ${activitiesToDownload.length} downloads failed`);
+      process.exitCode = 1;
     }
   }
 

--- a/src/command-runner/export-training-schedule.command-runner.ts
+++ b/src/command-runner/export-training-schedule.command-runner.ts
@@ -109,7 +109,7 @@ export class ExportTrainingScheduleCommandRunner extends CommandRunner {
         }
 
         const programId = entity.idInPlan ?? entity.planProgramId;
-        const program = programsById.get(programId);
+        const program = programId ? programsById.get(programId) : undefined;
         const summary = resolveSummary(entity, program, localeMap);
         const overview = resolveOverview(program, localeMap);
         const lengthText = formatPlannedLength(program, entity);

--- a/src/core/download-file.service.ts
+++ b/src/core/download-file.service.ts
@@ -19,6 +19,6 @@ export class DownloadFile {
       responseType: 'stream',
     });
 
-    await pipeline(response.data, fs.createWriteStream(path.join(directory, fileName)));
+    await pipeline(response.data, fs.createWriteStream(path.join(directory, path.basename(fileName))));
   }
 }

--- a/src/core/ics/build-calendar.spec.ts
+++ b/src/core/ics/build-calendar.spec.ts
@@ -1,9 +1,9 @@
 import dayjs from 'dayjs';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CalendarEvent } from './build-calendar';
 import { buildCalendar } from './build-calendar';
 
-const NOW_STAMP = '20260407T100000';
+const NOW_STAMP = '20260407T100000Z';
 
 const makeEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
   uid: 'test-uid-1',
@@ -71,6 +71,19 @@ describe('buildCalendar', () => {
   it('includes DTSTAMP with the provided nowStamp', () => {
     const result = buildCalendar([makeEvent()], undefined, NOW_STAMP);
     expect(result).toContain(`DTSTAMP:${NOW_STAMP}`);
+  });
+
+  describe('default DTSTAMP', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('is the current time in UTC with a Z suffix', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-07T10:00:00Z'));
+      const result = buildCalendar([makeEvent()], undefined);
+      expect(result).toContain('DTSTAMP:20260407T100000Z');
+    });
   });
 
   it('renders multiple events', () => {

--- a/src/core/ics/build-calendar.ts
+++ b/src/core/ics/build-calendar.ts
@@ -1,7 +1,10 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import type { TrainingStart } from '../../coros/training-schedule/parse-training-start';
 import { escapeText } from './escape-text';
 import { foldLine } from './fold-line';
+
+dayjs.extend(utc);
 
 export type CalendarEvent = {
   uid: string;
@@ -28,7 +31,8 @@ export const buildCalendar = (
   addLine('CALSCALE:GREGORIAN');
   addLine('METHOD:PUBLISH');
 
-  const stamp = nowStamp ?? dayjs().format('YYYYMMDDTHHmmss');
+  // RFC 5545 §3.8.7.2: DTSTAMP must be a UTC timestamp
+  const stamp = nowStamp ?? dayjs().utc().format('YYYYMMDDTHHmmss[Z]');
   for (const event of events) {
     addLine('BEGIN:VEVENT');
     addLine(`UID:${escapeText(event.uid)}`);

--- a/src/core/ics/fold-line.spec.ts
+++ b/src/core/ics/fold-line.spec.ts
@@ -2,10 +2,13 @@ import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import { foldLine } from './fold-line';
 
+const octetLength = (value: string) => new TextEncoder().encode(value).length;
+
 describe('foldLine', () => {
-  it('returns a single-element array for strings <= 75 chars', () => {
+  it('returns a single-element array for strings <= 75 octets', () => {
     fc.assert(
       fc.property(fc.string({ maxLength: 75 }), (line) => {
+        fc.pre(octetLength(line) <= 75);
         const result = foldLine(line);
         expect(result).toHaveLength(1);
         expect(result[0]).toBe(line);
@@ -13,12 +16,12 @@ describe('foldLine', () => {
     );
   });
 
-  it('every segment is at most 75 characters', () => {
+  it('every segment is at most 75 octets', () => {
     fc.assert(
-      fc.property(fc.string({ maxLength: 500 }), (line) => {
+      fc.property(fc.string({ unit: 'grapheme', maxLength: 500 }), (line) => {
         const result = foldLine(line);
         for (const segment of result) {
-          expect(segment.length).toBeLessThanOrEqual(75);
+          expect(octetLength(segment)).toBeLessThanOrEqual(75);
         }
       }),
     );
@@ -26,7 +29,7 @@ describe('foldLine', () => {
 
   it('concatenating segments (stripping continuation space) reproduces the original', () => {
     fc.assert(
-      fc.property(fc.string({ maxLength: 500 }), (line) => {
+      fc.property(fc.string({ unit: 'grapheme', maxLength: 500 }), (line) => {
         const result = foldLine(line);
         const reconstructed = result.map((segment, index) => (index === 0 ? segment : segment.slice(1))).join('');
         expect(reconstructed).toBe(line);
@@ -60,5 +63,24 @@ describe('foldLine', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toBe('a'.repeat(75));
     expect(result[1]).toBe(' a');
+  });
+
+  it('folds on octets for multi-byte characters', () => {
+    // 'é' is 2 octets in UTF-8: 50 of them (100 octets) exceed the 75-octet limit at 37 characters
+    const line = 'é'.repeat(50);
+    const result = foldLine(line);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe('é'.repeat(37));
+    expect(result[1]).toBe(` ${'é'.repeat(13)}`);
+  });
+
+  it('never splits a multi-byte character across segments', () => {
+    fc.assert(
+      fc.property(fc.string({ unit: 'binary', maxLength: 300 }), (line) => {
+        const result = foldLine(line);
+        const reconstructed = result.map((segment, index) => (index === 0 ? segment : segment.slice(1))).join('');
+        expect(reconstructed).toBe(line);
+      }),
+    );
   });
 });

--- a/src/core/ics/fold-line.ts
+++ b/src/core/ics/fold-line.ts
@@ -1,18 +1,29 @@
+const encoder = new TextEncoder();
+
+// RFC 5545 §3.1: lines longer than 75 octets (not characters) should be folded
 export const foldLine = (line: string): string[] => {
-  const maxLength = 75;
-  if (line.length <= maxLength) {
+  const maxOctets = 75;
+  if (encoder.encode(line).length <= maxOctets) {
     return [line];
   }
 
   const segments: string[] = [];
-  let remaining = line;
-  let isFirst = true;
-  while (remaining.length > 0) {
-    const chunkSize = isFirst ? maxLength : maxLength - 1;
-    segments.push(remaining.slice(0, chunkSize));
-    remaining = remaining.slice(chunkSize);
-    isFirst = false;
+  let current = '';
+  let currentOctets = 0;
+  // Continuation lines are prefixed with a space, leaving 74 octets for content
+  let limit = maxOctets;
+  for (const char of line) {
+    const charOctets = encoder.encode(char).length;
+    if (currentOctets + charOctets > limit) {
+      segments.push(current);
+      current = '';
+      currentOctets = 0;
+      limit = maxOctets - 1;
+    }
+    current += char;
+    currentOctets += charOctets;
   }
+  segments.push(current);
 
   return segments.map((segment, index) => (index === 0 ? segment : ` ${segment}`));
 };

--- a/src/core/parse-out-dir.spec.ts
+++ b/src/core/parse-out-dir.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -23,5 +23,11 @@ describe('parseOutDir', () => {
   it('throws InvalidParameterError when the directory does not exist', () => {
     const nonExistent = path.join(tmpDir, 'does-not-exist');
     expect(() => parseOutDir(nonExistent)).toThrow(InvalidParameterError);
+  });
+
+  it('throws InvalidParameterError when the path is a file', async () => {
+    const filePath = path.join(tmpDir, 'a-file.txt');
+    await writeFile(filePath, 'content');
+    expect(() => parseOutDir(filePath)).toThrow(InvalidParameterError);
   });
 });

--- a/src/core/parse-out-dir.ts
+++ b/src/core/parse-out-dir.ts
@@ -1,9 +1,10 @@
-import { existsSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import { InvalidParameterError } from './invalid-parameter-error';
 
 export const parseOutDir = (out: string): string => {
-  if (!existsSync(out)) {
-    throw new InvalidParameterError('out', out, 'Directory does not exists');
+  const stats = statSync(out, { throwIfNoEntry: false });
+  if (!stats?.isDirectory()) {
+    throw new InvalidParameterError('out', out, 'Directory does not exist');
   }
 
   return out;

--- a/src/core/redact-access-token.ts
+++ b/src/core/redact-access-token.ts
@@ -1,0 +1,15 @@
+export const redactAccessToken = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(redactAccessToken);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) =>
+        key.toLowerCase() === 'accesstoken' ? [key, '<redacted>'] : [key, redactAccessToken(entry)],
+      ),
+    );
+  }
+
+  return value;
+};

--- a/src/coros/account/login.request.ts
+++ b/src/coros/account/login.request.ts
@@ -3,6 +3,7 @@ import { URL } from 'node:url';
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 import { z } from 'zod';
+import { redactAccessToken } from '../../core/redact-access-token';
 import { BaseRequest } from '../base-request';
 import { CorosResponse } from '../common';
 import { CorosConfigService } from '../coros.config';
@@ -27,7 +28,7 @@ const LoginInput = z.object({});
 type LoginInput = z.infer<typeof LoginInput>;
 
 @Injectable()
-export class LoginRequest extends BaseRequest<LoginInput, LoginResponse, Omit<LoginData, 'accessToken'>> {
+export class LoginRequest extends BaseRequest<LoginInput, LoginResponse, void> {
   private readonly logger = new Logger(LoginRequest.name);
   private readonly httpService: HttpService;
   private readonly corosConfig: CorosConfigService;
@@ -52,23 +53,21 @@ export class LoginRequest extends BaseRequest<LoginInput, LoginResponse, Omit<Lo
     return LoginResponse;
   }
 
-  protected async handle(_: LoginInput): Promise<Omit<LoginData, 'accessToken'>> {
+  protected async handle(_: LoginInput): Promise<void> {
     const url = new URL('/account/login', this.corosConfig.apiUrl);
     const { data } = await this.httpService.axiosRef.post(url.toString(), {
       account: this.corosConfig.email,
       accountType: 2,
       pwd: createHash('md5').update(this.corosConfig.password).digest('hex'),
     } satisfies LoginBody);
-    this.logger.verbose('Login request response', data);
+    this.logger.verbose('Login request response', redactAccessToken(data));
 
     this.assertCorosResponseBase(data);
     this.assertCorosResponse(data);
 
     const {
-      data: { accessToken, ...rest },
+      data: { accessToken },
     } = data;
     this.corosAuthenticationService.accessToken = accessToken;
-
-    return rest;
   }
 }

--- a/src/coros/activity/download-activity-detail.request.ts
+++ b/src/coros/activity/download-activity-detail.request.ts
@@ -15,7 +15,7 @@ export const DownloadActivityDetailInput = z.object({
 export type DownloadActivityDetailInput = z.infer<typeof DownloadActivityDetailInput>;
 
 export const DownloadActivityDetailData = z.object({
-  fileUrl: z.string(),
+  fileUrl: z.url(),
 });
 export type DownloadActivityDetailData = z.infer<typeof DownloadActivityDetailData>;
 
@@ -51,7 +51,11 @@ export class DownloadActivityDetailRequest extends BaseRequest<
     return DownloadActivityDetailResponse;
   }
 
-  async handle({ labelId, sportType, fileType }: DownloadActivityDetailInput): Promise<DownloadActivityDetailData> {
+  protected async handle({
+    labelId,
+    sportType,
+    fileType,
+  }: DownloadActivityDetailInput): Promise<DownloadActivityDetailData> {
     const url = new URL('/activity/detail/download', this.corosConfig.apiUrl);
     url.searchParams.append('labelId', labelId);
     url.searchParams.append('sportType', String(sportType));

--- a/src/coros/activity/query-activities.request.ts
+++ b/src/coros/activity/query-activities.request.ts
@@ -71,7 +71,7 @@ export class QueryActivitiesRequest extends BaseRequest<
     return QueryActivitiesResponse;
   }
 
-  async handle({
+  protected async handle({
     pageSize = 20,
     pageNumber = 1,
     from,
@@ -103,38 +103,43 @@ export class QueryActivitiesRequest extends BaseRequest<
     to?: Date;
     modeList: string;
   }): Promise<Activity[]> {
-    const url = new URL('/activity/query', this.corosConfig.apiUrl);
-    url.searchParams.append('size', String(pageSize));
-    url.searchParams.append('pageNumber', String(pageNumber));
-    url.searchParams.append('modeList', modeList);
+    const activities: Activity[] = [];
+    let currentPage = pageNumber;
+    let lastPage = pageNumber;
 
-    if (from) {
-      url.searchParams.append('startDay', dayjs(from).format('YYYYMMDD'));
-    }
+    do {
+      const url = new URL('/activity/query', this.corosConfig.apiUrl);
+      url.searchParams.append('size', String(pageSize));
+      url.searchParams.append('pageNumber', String(currentPage));
+      url.searchParams.append('modeList', modeList);
 
-    if (to) {
-      url.searchParams.append('endDay', dayjs(to).format('YYYYMMDD'));
-    }
+      if (from) {
+        url.searchParams.append('startDay', dayjs(from).format('YYYYMMDD'));
+      }
 
-    const { data } = await this.httpService.axiosRef.get(url.toString(), {
-      headers: {
-        accessToken: this.corosAuthenticationService.accessToken,
-      },
-    });
-    this.logger.verbose('Query activity response', data);
+      if (to) {
+        url.searchParams.append('endDay', dayjs(to).format('YYYYMMDD'));
+      }
 
-    this.assertCorosResponseBase(data);
-    this.assertCorosResponse(data);
+      const { data } = await this.httpService.axiosRef.get(url.toString(), {
+        headers: {
+          accessToken: this.corosAuthenticationService.accessToken,
+        },
+      });
+      this.logger.verbose('Query activity response', data);
 
-    const {
-      data: { dataList, totalPage },
-    } = data;
+      this.assertCorosResponseBase(data);
+      this.assertCorosResponse(data);
 
-    const activities = [...(dataList ?? [])];
-    if (pageNumber < (totalPage ?? 0)) {
-      const next = await this.getActivities({ pageSize, pageNumber: pageNumber + 1, from, to, modeList });
-      activities.push(...next);
-    }
+      const {
+        data: { dataList, totalPage },
+      } = data;
+
+      activities.push(...(dataList ?? []));
+      lastPage = totalPage ?? 0;
+      currentPage += 1;
+    } while (currentPage <= lastPage);
+
     return activities;
   }
 }

--- a/src/coros/base-request.spec.ts
+++ b/src/coros/base-request.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { ValidationError } from '../core/validation-error';
+import { BaseRequest } from './base-request';
+import { CorosResponse } from './common';
+
+const TestInput = z.object({
+  name: z.string(),
+  flag: z.number().default(1),
+});
+type TestInput = z.infer<typeof TestInput>;
+
+const TestData = z.object({
+  accessToken: z.string(),
+  required: z.string(),
+});
+
+const TestResponse = CorosResponse(TestData);
+type TestResponse = z.infer<typeof TestResponse>;
+
+class TestRequest extends BaseRequest<TestInput, TestResponse, TestInput> {
+  protected inputValidator(): z.Schema<TestInput> {
+    return TestInput;
+  }
+
+  protected responseValidator(): z.Schema<TestResponse> {
+    return TestResponse;
+  }
+
+  protected async handle(args: TestInput): Promise<TestInput> {
+    return args;
+  }
+
+  public assertBase(data: unknown): void {
+    this.assertCorosResponseBase(data);
+  }
+
+  public assertResponse(data: unknown): void {
+    this.assertCorosResponse(data);
+  }
+}
+
+describe('BaseRequest', () => {
+  describe('run', () => {
+    it('passes the parsed input to handle, with schema defaults applied', async () => {
+      const request = new TestRequest();
+      const received = await request.run({ name: 'a name' } as TestInput);
+      expect(received).toEqual({ name: 'a name', flag: 1 });
+    });
+
+    it('throws ValidationError when the input is invalid', async () => {
+      const request = new TestRequest();
+      await expect(request.run({} as TestInput)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('assertCorosResponseBase', () => {
+    it('accepts a well-formed successful response', () => {
+      const request = new TestRequest();
+      expect(() => request.assertBase({ apiCode: 'api', message: 'OK', result: '0000' })).not.toThrow();
+    });
+
+    it('throws ValidationError when the response shape is invalid', () => {
+      const request = new TestRequest();
+      expect(() => request.assertBase({ unexpected: true })).toThrow(ValidationError);
+    });
+
+    it('throws the API message when result is not 0000', () => {
+      const request = new TestRequest();
+      expect(() => request.assertBase({ apiCode: 'api', message: 'Invalid credentials', result: '1001' })).toThrow(
+        'Invalid credentials',
+      );
+    });
+  });
+
+  describe('assertCorosResponse', () => {
+    it('throws ValidationError with the accessToken redacted from the cause', () => {
+      const request = new TestRequest();
+      const response = {
+        apiCode: 'api',
+        message: 'OK',
+        result: '0000',
+        data: { accessToken: 'secret-token' },
+      };
+
+      let thrown: unknown;
+      try {
+        request.assertResponse(response);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(ValidationError);
+      const { cause } = thrown as ValidationError;
+      expect(JSON.stringify(cause)).not.toContain('secret-token');
+      expect(JSON.stringify(cause)).toContain('<redacted>');
+    });
+  });
+});

--- a/src/coros/base-request.ts
+++ b/src/coros/base-request.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { redactAccessToken } from '../core/redact-access-token';
 import { ValidationError } from '../core/validation-error';
 import { CorosResponseBase, type CorosResponseWithData } from './common';
 
@@ -12,14 +13,14 @@ export abstract class BaseRequest<Input, Response extends CorosResponseWithData,
     if (!parseResult.success) {
       throw new ValidationError(parseResult.error, { cause: args });
     }
-    return await this.handle(args);
+    return await this.handle(parseResult.data);
   }
 
   protected assertCorosResponseBase(data: unknown): asserts data is CorosResponseBase {
     const parseResult = CorosResponseBase.safeParse(data);
     if (!parseResult.success) {
       throw new ValidationError(parseResult.error, {
-        cause: data,
+        cause: redactAccessToken(data),
       });
     }
 
@@ -33,7 +34,7 @@ export abstract class BaseRequest<Input, Response extends CorosResponseWithData,
     const parseResult = this.responseValidator().safeParse(data);
     if (!parseResult.success) {
       throw new ValidationError(parseResult.error, {
-        cause: data,
+        cause: redactAccessToken(data),
       });
     }
   }

--- a/src/coros/coros.config.ts
+++ b/src/coros/coros.config.ts
@@ -3,9 +3,9 @@ import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 
 const CorosConfig = z.object({
-  apiUrl: z.string(),
-  email: z.string(),
-  password: z.string(),
+  apiUrl: z.url(),
+  email: z.string().min(1),
+  password: z.string().min(1),
 });
 type CorosConfig = z.infer<typeof CorosConfig>;
 

--- a/src/coros/sport-type.spec.ts
+++ b/src/coros/sport-type.spec.ts
@@ -1,0 +1,43 @@
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+import { DefaultSportType, getSportTypeValueFromKey, isValidSportTypeKey, SportTypeKeys } from './sport-type';
+
+const InvalidSportTypeArbitrary = fc.string().filter((sportType) => !SportTypeKeys.includes(sportType as never));
+
+describe('Sport Type', () => {
+  it('should return DefaultSportType', () => {
+    expect(DefaultSportType).toEqual({ key: 'all', value: '0' });
+  });
+
+  describe('isValidSportTypeKey', () => {
+    it.each(SportTypeKeys)('%s should be a valid sport type', (sportType) => {
+      expect(isValidSportTypeKey(sportType)).toBe(true);
+    });
+
+    it('should be an invalid sport type', () => {
+      fc.assert(
+        fc.property(InvalidSportTypeArbitrary, (input) => {
+          expect(isValidSportTypeKey(input)).toBe(false);
+        }),
+      );
+    });
+  });
+
+  describe('getSportTypeValueFromKey', () => {
+    it('should return the sport type value for all', () => {
+      expect(getSportTypeValueFromKey('all')).toBe('0');
+    });
+
+    it('should return the sport type value for run', () => {
+      expect(getSportTypeValueFromKey('run')).toBe('100');
+    });
+
+    it('should return the sport type value for bike', () => {
+      expect(getSportTypeValueFromKey('bike')).toBe('200');
+    });
+
+    it('should return the sport type value for triathlon', () => {
+      expect(getSportTypeValueFromKey('triathlon')).toBe('10000');
+    });
+  });
+});

--- a/src/coros/training-schedule/query-training-schedule.request.ts
+++ b/src/coros/training-schedule/query-training-schedule.request.ts
@@ -24,10 +24,10 @@ export const TrainingScheduleSportData = z.object({
 export type TrainingScheduleSportData = z.infer<typeof TrainingScheduleSportData>;
 
 export const TrainingScheduleEntity = z.object({
-  id: z.string(),
-  idInPlan: z.string(),
-  planProgramId: z.string(),
-  happenDay: z.string(),
+  id: z.string().optional(),
+  idInPlan: z.string().optional(),
+  planProgramId: z.string().optional(),
+  happenDay: z.string().optional(),
   sportData: TrainingScheduleSportData.optional(),
 });
 export type TrainingScheduleEntity = z.infer<typeof TrainingScheduleEntity>;
@@ -88,7 +88,7 @@ export class QueryTrainingScheduleRequest extends BaseRequest<
 
     const { data } = await this.httpService.axiosRef.get(url.toString(), {
       headers: {
-        accesstoken: this.corosAuthenticationService.accessToken,
+        accessToken: this.corosAuthenticationService.accessToken,
       },
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,10 @@ async function bootstrap() {
 
   await CommandFactory.run(AppModule, {
     logger: ['log', 'warn', 'error', 'fatal'],
-    serviceErrorHandler: (err) => logger.error(err),
+    serviceErrorHandler: (err) => {
+      logger.error(err);
+      process.exitCode = 1;
+    },
   });
 }
 void bootstrap();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
 
-    "outDir": "./dist",
-
-    "types": ["vitest/globals"]
+    "outDir": "./dist"
   }
 }


### PR DESCRIPTION
## What

A hardening pass over the export CLI covering security, calendar output correctness, and failure reporting:

- **Security**: access tokens are no longer written to logs or validation error output, and activity names coming from the COROS API can no longer escape the chosen output directory.
- **Calendar correctness**: exported ICS files now comply with RFC 5545 — long lines are folded by byte length (so accented and other multi-byte characters are never corrupted) and timestamps are emitted in UTC.
- **Reliability**: exporting a large activity history no longer risks crashing on deep pagination, option defaults are applied consistently, and schedules with missing fields no longer fail the whole export.
- **Failure reporting**: the CLI now exits with a non-zero status when downloads or commands fail, so scripts and cron jobs can detect failures.
- **Validation**: credentials and API URLs are checked up front with clearer error messages, including when the output path exists but is not a directory.

## Why

Tokens leaking into logs and silent failures (exit code 0 on partial/failed exports) made the CLI risky to run unattended. The ICS folding bug produced corrupted calendar entries for activity names with non-ASCII characters.

Also adds test coverage for the new behavior and enables dependency caching in CI.