### PR TITLE
ci: gate the GitHub Actions lint workflow

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -2,9 +2,6 @@ name: Lint GitHub Actions
 
 on:
   pull_request:
-  push:
-    branches: [main]
-  workflow_dispatch:
 
 permissions: {}
 
@@ -13,13 +10,28 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  changes:
+    name: Detect workflow changes
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      github: ${{ steps.filter.outputs.github }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            github:
+              - '.github/**'
+
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.github == 'true'
     runs-on: ubuntu-24.04
-
     permissions:
       contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -34,7 +46,6 @@ jobs:
           advanced-security: false
           annotations: true
 
-      # actionlint has no pinnable action; fetched by tag, Renovate bumps ACTIONLINT_VERSION.
       - name: Run actionlint
         env:
           # renovate: datasource=github-releases depName=rhysd/actionlint
@@ -50,3 +61,24 @@ jobs:
         uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
         with:
           fix: "false"
+
+  gate:
+    name: Lint gate
+    if: always()
+    needs: [changes, lint]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check lint outcome
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "Change detection did not succeed (result: $CHANGES_RESULT)"
+            exit 1
+          fi
+          if [ "$LINT_RESULT" = "failure" ] || [ "$LINT_RESULT" = "cancelled" ]; then
+            echo "Lint failed (result: $LINT_RESULT)"
+            exit 1
+          fi
+          echo "OK (changes: $CHANGES_RESULT, lint: $LINT_RESULT)"


### PR DESCRIPTION
## Overview

Upgrades the GitHub Actions lint workflow to a change-gated variant so it doubles as a stable required status check.

## Changes

- **`lint-actions.yml` → change-gated** — a `changes` job (`dorny/paths-filter`) runs the `zizmor` + `actionlint` + `pinact` lint job only when `.github/**` changes, behind an always-run `gate` job that stays green when lint is clean or skipped and fails closed on lint failure or broken change-detection. Renovate annotations for the `zizmor`/`actionlint` CLI versions and full SHA pins are preserved.

## Testing

The lint workflow validates itself: on this PR the `Lint GitHub Actions` run exercises `changes` → `lint` → `gate`. Locally verified clean with `actionlint`, `zizmor --min-severity low --min-confidence medium`, and `pinact run --check --verify`.
